### PR TITLE
SetRecordToScoreboard のローカル環境実行時の挙動の修正提案

### DIFF
--- a/plugins/AtsumaruScoreboardsExperimental.js
+++ b/plugins/AtsumaruScoreboardsExperimental.js
@@ -139,6 +139,8 @@
                                 break;
                         }
                     });
+            } else if (args.length > 2) {
+                $gameVariables.setValue(errorVariableId, 0);
             }
         } else if (command === "DisplayScoreboard") {
             if (args.length < 1) {

--- a/plugins/AtsumaruScoreboardsExperimental.js
+++ b/plugins/AtsumaruScoreboardsExperimental.js
@@ -58,7 +58,7 @@
  * 
  * アツマール外（テストプレイや他のサイト、ダウンロード版）での挙動:
  *      SetRecordToScoreboard
- *          無視される（変数<errorVariableId>には何もセットされない）
+ *          無視される（変数<errorVariableId>が指定されているなら即座に0がセットされる）
  *      DisplayScoreboard
  *          無視される
  *      FetchRecordsFromScoreboard


### PR DESCRIPTION
<!--
RPGアツマールへの pull request ありがとうございます！

pull request を提出する前に、以下のガイドラインを確認してください。
https://github.com/astumaru/api-reference/blob/master/CONTRIBUTING.md
-->

<!-- 以下に修正内容に関する説明をくわしく記述してください -->

https://github.com/atsumaru/mv-plugins/blob/19efa983369c7312ade89b90ac150e7fbd528fe8/plugins/AtsumaruScoreboardsExperimental.js#L59-L61
とあるのですが、 `SetRecordToScoreboard <boardId> <variableId> <errorVariableId>` を使用するケースでの実際の処理内容としては
「実行前に `errorVariableId` の変数を `0` 以外にしておく」→「実行」→「 `errorVariableId` の変数が `0` もしくは何らかの文字列へと変化するのを待つ」→「(必要に応じて) `DisplayScoreboard` や `FetchRecordsFromScoreboard` を実行する」
のような流れになると思います。
これをローカル環境でテストプレイする場合、何も変化しないのであれば、処理がここでストップしてしまいます。
ですので、ここは「即座に `0` をセットする」のような挙動の方が望ましいと思いますが、どうでしょうか。