### PR TITLE
fix(scroll): マウスホイールによるスクロールの不具合修正

### DIFF
--- a/plugins/AtsumaruAutoplayFix.js
+++ b/plugins/AtsumaruAutoplayFix.js
@@ -15,10 +15,14 @@
     }
 
     /*:
-     * @plugindesc すべてのブラウザで自動再生起因による動画再生の失敗を修正するプラグインです。 コアスクリプトの https://github.com/rpgtkoolmv/corescript/pull/140 こちらの修正の先行実装になります。
+     * @plugindesc すべてのブラウザで自動再生起因による動画再生の失敗を修正するプラグインです。
      * @author RPGアツマール開発チーム
      *
-     * @help プラグインを有効にするだけで動画再生の修正を行います。
+     * @help
+     * プラグインを有効にするだけで動画再生の修正を行います。
+     * コミュニティ版コアスクリプトにて対応される修正
+     * (https://github.com/rpgtkoolmv/corescript/pull/140)
+     * の先行実装になります。
      */
     hookStatic(Graphics, "initialize", function (origin) { return function () {
         origin.apply(this, arguments);

--- a/plugins/WheelFix.js
+++ b/plugins/WheelFix.js
@@ -1,0 +1,33 @@
+//=============================================================================
+// WheelFix.js
+//
+// Copyright (c) 2018 RPGアツマール開発チーム(https://game.nicovideo.jp/atsumaru)
+// Released under the MIT license
+// http://opensource.org/licenses/mit-license.php
+//=============================================================================
+
+(function () {
+    'use strict';
+
+    /*:
+     * @plugindesc マウスホイール動作の不具合を修正します。
+     * @author RPGアツマール開発チーム
+     *
+     * @help
+     * Google Chromeにてマウスホイールでゲーム画面そのものが
+     * 上下にスクロールしてしまう不具合を修正します。
+     * プラグインを有効にするだけで、修正を行います。
+     *
+     * コミュニティ版コアスクリプトにて対応される修正
+     * (https://github.com/rpgtkoolmv/corescript/pull/202)
+     * の先行実装になります。
+     */
+    var options = Object.defineProperty({}, "passive", {
+        get: function () {
+            document.addEventListener("wheel", function (event) { event.preventDefault(); }, { passive: false });
+        }
+    });
+    window.addEventListener("test", null, options);
+    window.removeEventListener("test", null, options);
+
+}());

--- a/src/AtsumaruAutoplayFix.ts
+++ b/src/AtsumaruAutoplayFix.ts
@@ -1,8 +1,12 @@
 /*:
- * @plugindesc すべてのブラウザで自動再生起因による動画再生の失敗を修正するプラグインです。 コアスクリプトの https://github.com/rpgtkoolmv/corescript/pull/140 こちらの修正の先行実装になります。
+ * @plugindesc すべてのブラウザで自動再生起因による動画再生の失敗を修正するプラグインです。
  * @author RPGアツマール開発チーム
  *
- * @help プラグインを有効にするだけで動画再生の修正を行います。
+ * @help
+ * プラグインを有効にするだけで動画再生の修正を行います。
+ * コミュニティ版コアスクリプトにて対応される修正
+ * (https://github.com/rpgtkoolmv/corescript/pull/140)
+ * の先行実装になります。
  */
 
 import { hookStatic } from "./utils/rmmvbridge";

--- a/src/WheelFix.ts
+++ b/src/WheelFix.ts
@@ -1,0 +1,21 @@
+/*:
+ * @plugindesc マウスホイール動作の不具合を修正します。
+ * @author RPGアツマール開発チーム
+ *
+ * @help
+ * Google Chromeにてマウスホイールでゲーム画面そのものが
+ * 上下にスクロールしてしまう不具合を修正します。
+ * プラグインを有効にするだけで、修正を行います。
+ *
+ * コミュニティ版コアスクリプトにて対応される修正
+ * (https://github.com/rpgtkoolmv/corescript/pull/202)
+ * の先行実装になります。
+ */
+
+const options = Object.defineProperty({}, "passive", {
+    get: function() {
+        document.addEventListener("wheel", function(event) { event.preventDefault(); }, { passive: false });
+    }
+});
+window.addEventListener("test", null, options);
+window.removeEventListener("test", null, options);


### PR DESCRIPTION
### 概要

最新のGoogle Chromeの仕様変更によって、ツクールMVのゲームをプレイ中にゲーム内のウィンドウをマウスホイールで上下させようとすると、ゲームページ自体が上下してしまうようになってしまいました。この問題を修正するためのプラグインです。